### PR TITLE
Fixed possible NullPointerException when encountering unknown device

### DIFF
--- a/bundles/binding/org.openhab.binding.maxcube/src/main/java/org/openhab/binding/maxcube/internal/message/L_Message.java
+++ b/bundles/binding/org.openhab.binding.maxcube/src/main/java/org/openhab/binding/maxcube/internal/message/L_Message.java
@@ -31,25 +31,27 @@ public final class L_Message extends Message {
 	public Collection<? extends Device> getDevices(List<Configuration> configurations) {
 
 		List<Device> devices = new ArrayList<Device>();
-		
+
 		byte[] decodedRawMessage = Base64.decodeBase64(getPayload().getBytes());
-	
+
 		MaxTokenizer tokenizer = new MaxTokenizer(decodedRawMessage);
 
 		while (tokenizer.hasMoreElements()) {
 			byte[] token = tokenizer.nextElement();
-
-			devices.add(Device.create(token, configurations));
+			Device tempDevice = Device.create(token, configurations);
+			if (tempDevice != null) {
+				devices.add(tempDevice);
+			}
 		}
-		
+
 		return devices;
 	}
-	
+
 	@Override
 	public void debug(Logger logger) {
 		logger.debug("=== L_Message === ");
 		logger.debug("\tRAW:" + this.getPayload());
-	}	
+	}
 
 	@Override
 	public MessageType getType() {

--- a/bundles/binding/org.openhab.binding.maxcube/src/main/java/org/openhab/binding/maxcube/internal/message/UnsupportedDevice.java
+++ b/bundles/binding/org.openhab.binding.maxcube/src/main/java/org/openhab/binding/maxcube/internal/message/UnsupportedDevice.java
@@ -1,0 +1,27 @@
+package org.openhab.binding.maxcube.internal.message;
+
+import java.util.Calendar;
+
+public class UnsupportedDevice extends Device {
+
+	public UnsupportedDevice(Configuration c) {
+		super(c);
+	}
+
+	@Override
+	public DeviceType getType() {
+		return DeviceType.Invalid;
+	}
+
+	@Override
+	public String getName() {
+		return "Unsupported device";
+	}
+
+	@Override
+	public Calendar getLastUpdate() {
+		// TODO Auto-generated method stub
+		return null;
+	}
+
+}


### PR DESCRIPTION
I introduced UnsupportedDevice so null is never returned when creating devices. I also added a little bit more logging.
