### PR TITLE
Fix thermostatplus reading & increase debug info M message

### DIFF
--- a/bundles/binding/org.openhab.binding.maxcube/src/main/java/org/openhab/binding/maxcube/internal/MaxCubeBinding.java
+++ b/bundles/binding/org.openhab.binding.maxcube/src/main/java/org/openhab/binding/maxcube/internal/MaxCubeBinding.java
@@ -215,6 +215,7 @@ public class MaxCubeBinding extends AbstractActiveBinding<MaxCubeBindingProvider
 					}
 
 					switch (device.getType()) {
+					case HeatingThermostatPlus:
 					case HeatingThermostat:
 						if (provider.getBindingType(itemName) == BindingType.VALVE) {
 							eventPublisher.postUpdate(itemName, ((HeatingThermostat) device).getValvePosition());

--- a/bundles/binding/org.openhab.binding.maxcube/src/main/java/org/openhab/binding/maxcube/internal/Utils.java
+++ b/bundles/binding/org.openhab.binding.maxcube/src/main/java/org/openhab/binding/maxcube/internal/Utils.java
@@ -151,6 +151,29 @@ public final class Utils {
 
 		return data;
 	}
+
+	/**
+	 *  Convert a byte array to a string representation of hexadecimals.
+	 *   
+	 * For example:
+	 * byte array is {0x00, 0x01, 0x03}
+	 * returned String s = "00010203"
+	 *
+	 * @param byte array 
+	 * @return String equivalent to hex string
+	 **/
+	static final String HEXES = "0123456789ABCDEF";
+	public static String getHex( byte [] raw ) {
+	    if ( raw == null ) {
+	        return null;
+	    }
+	    final StringBuilder hex = new StringBuilder( 2 * raw.length );
+	    for ( final byte b : raw ) {
+	        hex.append(HEXES.charAt((b & 0xF0) >> 4))
+	            .append(HEXES.charAt((b & 0x0F)));
+	    }
+	    return hex.toString();
+	}
 	
 	/**
 	 * Retrieves the stacktrace of an exception as string.

--- a/bundles/binding/org.openhab.binding.maxcube/src/main/java/org/openhab/binding/maxcube/internal/message/Device.java
+++ b/bundles/binding/org.openhab.binding.maxcube/src/main/java/org/openhab/binding/maxcube/internal/message/Device.java
@@ -60,6 +60,7 @@ public abstract class Device {
 		for (Configuration c : configurations) {
 			if (c.getRFAddress().toUpperCase().equals(rfAddress.toUpperCase())) {
 				switch (c.getDeviceType()) {
+				case HeatingThermostatPlus:
 				case HeatingThermostat:
 					return new HeatingThermostat(c);
 				case ShutterContact:

--- a/bundles/binding/org.openhab.binding.maxcube/src/main/java/org/openhab/binding/maxcube/internal/message/DeviceType.java
+++ b/bundles/binding/org.openhab.binding.maxcube/src/main/java/org/openhab/binding/maxcube/internal/message/DeviceType.java
@@ -15,7 +15,7 @@ package org.openhab.binding.maxcube.internal.message;
 * @since 1.4.0
 */
 public enum DeviceType {
-	Invalid(256), HeatingThermostat(1), HeatingThermostatPlus(2), WallMountedThermostat(
+	Invalid(256), Cube (0), HeatingThermostat(1), HeatingThermostatPlus(2), WallMountedThermostat(
 			3), ShutterContact(4), PushButton(5);
 
 	private int value;
@@ -30,6 +30,8 @@ public enum DeviceType {
 	
 	public static DeviceType create(int value) {
 		switch(value) {
+		case 0:
+	    	return Cube;
 		case 1:
 			return HeatingThermostat;
 		case 2:
@@ -47,6 +49,8 @@ public enum DeviceType {
 	
 	public String toString() {
 	    switch(value) {
+	    case 0:
+	    	return "Cube";
 	    case 1:
 	      return "Thermostat";
 	    case 2:

--- a/bundles/binding/org.openhab.binding.maxcube/src/main/java/org/openhab/binding/maxcube/internal/message/H_Message.java
+++ b/bundles/binding/org.openhab.binding.maxcube/src/main/java/org/openhab/binding/maxcube/internal/message/H_Message.java
@@ -77,7 +77,7 @@ public final class H_Message extends Message {
 	@Override
 	public void debug(Logger logger) {
 		logger.debug("=== H_Message === ");
-		logger.debug("\tRAW:             " + this.getPayload());
+		logger.trace("\tRAW:             " + this.getPayload());
 		logger.debug("\tReading Time:    " + cal.getTime());
 		logger.debug("\tSerial number:   " + rawSerialNumber);
 		logger.debug("\tRF address (HEX):" + rawRfHexAddress);

--- a/bundles/binding/org.openhab.binding.maxcube/src/main/java/org/openhab/binding/maxcube/internal/message/M_Message.java
+++ b/bundles/binding/org.openhab.binding.maxcube/src/main/java/org/openhab/binding/maxcube/internal/message/M_Message.java
@@ -13,6 +13,7 @@ import java.util.ArrayList;
 import org.apache.commons.codec.binary.Base64;
 import org.openhab.binding.maxcube.internal.Utils;
 import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
 * The M message contains metadata about the MAX!Cube setup. 
@@ -25,12 +26,14 @@ public final class M_Message extends Message {
 	public ArrayList<RoomInformation> rooms;
 	public ArrayList<DeviceInformation> devices;
 	
+	
 	public M_Message(String raw) {
 		super(raw);
 		
+		
 		String[] tokens = this.getPayload().split(Message.DELIMETER);
 		byte[] bytes = Base64.decodeBase64(tokens[2].getBytes());
-		
+			
 		rooms = new ArrayList<RoomInformation>();
 		devices = new ArrayList<DeviceInformation>();
 		
@@ -82,14 +85,34 @@ public final class M_Message extends Message {
 
 			 int roomId = (int)bytes[byteOffset++] & 0xff;
 
-			 devices.add(new DeviceInformation(deviceType, serialNumber, rfAddress, deviceName, roomId));	  
+			 devices.add(new DeviceInformation(deviceType, serialNumber, rfAddress, deviceName, roomId));	
+		
+			 
 		 }
 	}
 	
 	@Override
 	public void debug(Logger logger) {
 		logger.debug("=== M_Message === ");
-		logger.debug("\tRAW:" + this.getPayload());
+		logger.trace("\tRAW:" + this.getPayload());
+		for(RoomInformation room: rooms){
+			 logger.debug("\t=== Rooms ===");
+			 logger.debug("\tRoom Pos:  " + room.getPosition());
+			 logger.debug("\tRoom Name: " + room.getName());
+			 logger.debug("\tRoom RF Adr:" +  room.getRFAddress());
+			 for(DeviceInformation device: devices){
+				 if (room.getPosition() == device.getRoomId()) {
+					 logger.debug("\t=== Devices ===");
+					 logger.debug("\tDevice Type :      " + device.getDeviceType());
+					 logger.debug("\tDevice Name:       " + device.getName());
+					 logger.debug("\tDevice Serialnr :  " + device.getSerialNumber());
+					 logger.debug("\tDevice RF Adr :    " + device.getRFAddress());
+					 logger.debug("\tRoom Id:           " + device.getRoomId());
+				 }
+			 }
+
+		}
+		
 	}
 
 	@Override


### PR DESCRIPTION
This fixes the missing of the reading for the ThermosthatPlus device by adding 2x case HeatingThermostatPlus: at the appropriate places.
Also it adds some more readable debug info while moving the raw string as trace info instead of debug
